### PR TITLE
Implement support for MTConnect Agent commands 

### DIFF
--- a/src/MTCAdapter.cs
+++ b/src/MTCAdapter.cs
@@ -170,7 +170,7 @@ namespace MTConnect
         public Adapter(int aPort = 7878, bool verbose = false)
         {
             mPort = aPort;
-            _commandsToSendOnConnect = new List<Tuple<MTConnectDeviceCommand, string>>
+            _commandsToSendOnConnect = new List<Tuple<MTConnectDeviceCommand, string>>();
             Heartbeat = 10000;
             Verbose = verbose;
         }

--- a/src/MTCAdapter.cs
+++ b/src/MTCAdapter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright Copyright 2012, System Insights, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,7 +44,8 @@ namespace MTConnect
         ConversionRequired, // {yes, no}
         RelativeTime, // {yes, no}
         RealTime, // {yes, no}
-        Device
+        Device,
+        UUID
     }
 
     /// <summary>
@@ -55,16 +56,17 @@ namespace MTConnect
 
         private static Dictionary<MTConnectDeviceCommand, string> _commandConverter = new Dictionary<MTConnectDeviceCommand, string>
         {
-            {MTConnectDeviceCommand.Manufacturer, "manufacturer"},
-            {MTConnectDeviceCommand.Station, "station"},
-            {MTConnectDeviceCommand.SerialNumber, "serialNumber"},
-            {MTConnectDeviceCommand.Description, "description"},
-            {MTConnectDeviceCommand.NativeName, "nativeName"},
-            {MTConnectDeviceCommand.Calibration, "calibration"},
-            {MTConnectDeviceCommand.ConversionRequired, "conversionRequired"},
-            {MTConnectDeviceCommand.RelativeTime, "relativeTime"},
-            {MTConnectDeviceCommand.RealTime, "realTime"},
-            {MTConnectDeviceCommand.Device, "device"}
+            { MTConnectDeviceCommand.Manufacturer, "manufacturer" },
+            { MTConnectDeviceCommand.Station, "station" },
+            { MTConnectDeviceCommand.SerialNumber, "serialNumber" },
+            { MTConnectDeviceCommand.Description, "description" },
+            { MTConnectDeviceCommand.NativeName, "nativeName" },
+            { MTConnectDeviceCommand.Calibration, "calibration" },
+            { MTConnectDeviceCommand.ConversionRequired, "conversionRequired" },
+            { MTConnectDeviceCommand.RelativeTime, "relativeTime" },
+            { MTConnectDeviceCommand.RealTime, "realTime" },
+            { MTConnectDeviceCommand.Device, "device" }, 
+            { MTConnectDeviceCommand.UUID, "uuid" }
         };
         /// <summary>
         /// The listening thread for new connections

--- a/src/MTCAdapter.cs
+++ b/src/MTCAdapter.cs
@@ -588,11 +588,11 @@ namespace MTConnect
                     clientThread.Start(client);
 
                     SendAllTo(client.GetStream());
-                    clientThread.Join();
                     foreach(Tuple<MTConnectDeviceCommand, string> tuple in _commandsToSendOnConnect)
                     {
                         SendCommand(tuple.Item1, tuple.Item2, false);
                     }
+                    clientThread.Join();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
The reference [cppagent project](https://github.com/mtconnect/cppagent) has support for command messages that modify or create properties of a Device component specified in the devices.xml file. This branch allows consumers of the SDK to use this functionality.

The UUID command requires that agent configuration file sets `PreserveUUID = false` as the device.xml is intended to be a static description of the MTConnect agent (ignoring @ASSET messages).